### PR TITLE
Add postgresql-client to fix migration job

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,7 +22,8 @@ WORKDIR /app
 # Install only runtime dependencies
 RUN apk add --no-cache \
     libpq \
-    libffi
+    libffi \
+    postgresql-client
 
 # Copy Python packages from builder
 COPY --from=builder /root/.local /root/.local


### PR DESCRIPTION
This pull request makes a minor update to the `backend/Dockerfile` by adding the `postgresql-client` package to the runtime dependencies. This ensures that the container has the necessary tools to interact with PostgreSQL databases at runtime.