### PR TITLE
Include migrations in image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=builder /root/.local /root/.local
 
 # Copy only necessary application code
 COPY app ./app
+COPY alembic ./alembic
 COPY alembic.ini ./
 
 # Make sure scripts in .local are usable


### PR DESCRIPTION
This pull request makes a small update to the Docker build process. The change ensures that the `alembic` directory is included in the final Docker image, which is necessary for database migrations to work correctly.