### PR TITLE
[#24] Add exercise notes functionality

### DIFF
--- a/backend/alembic/versions/0258799edde7_add_notes_to_workout_exercises.py
+++ b/backend/alembic/versions/0258799edde7_add_notes_to_workout_exercises.py
@@ -1,0 +1,28 @@
+"""add_notes_to_workout_exercises
+
+Revision ID: 0258799edde7
+Revises: b8c3e9f12345
+Create Date: 2025-12-29 21:39:06.604529
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0258799edde7'
+down_revision: Union[str, Sequence[str], None] = 'b8c3e9f12345'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('workout_exercises', sa.Column('notes', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('workout_exercises', 'notes')

--- a/backend/app/crud/workouts.py
+++ b/backend/app/crud/workouts.py
@@ -15,7 +15,8 @@ def create_workout(db: Session, payload, user_id: str):
         workout_ex = WorkoutExercise(
             workout_id=workout.id,
             exercise_id=ex.exercise_id,
-            exercise_name=ex.name  # Changed from exercise_name to name
+            exercise_name=ex.name,  # Changed from exercise_name to name
+            notes=ex.notes  # Add notes field
         )
         db.add(workout_ex)
         db.flush()

--- a/backend/app/models/set.py
+++ b/backend/app/models/set.py
@@ -11,6 +11,7 @@ class WorkoutExercise(Base):
     exercise_id = Column(String)
     exercise_name = Column(String)
     muscles = Column(JSON, nullable=True)  # Add muscles field for denormalized data
+    notes = Column(String, nullable=True)  # Add notes field for exercise notes
 
     workout = relationship("Workout", back_populates="exercises")
     sets = relationship(

--- a/backend/app/schemas/workout.py
+++ b/backend/app/schemas/workout.py
@@ -10,6 +10,7 @@ class SetCreate(BaseModel):
 class WorkoutExerciseCreate(BaseModel):
     exercise_id: str
     name: str  # Accept 'name' from frontend
+    notes: Optional[str] = ''
     sets: List[SetCreate]
 
 class WorkoutCreate(BaseModel):
@@ -31,6 +32,7 @@ class WorkoutExerciseOut(BaseModel):
     exercise_id: str
     exercise_name: str
     muscles: Optional[List[str]] = []
+    notes: Optional[str] = ''
     sets: List[SetOut]
 
     class Config:

--- a/frontend/src/views/ProgressView.vue
+++ b/frontend/src/views/ProgressView.vue
@@ -103,6 +103,17 @@
           class="bg-[#0a0a0a] border border-[#2a2a2a] rounded-xl p-4"
         >
           <h3 class="font-semibold text-lg mb-3">{{ exercise.exercise_name }}</h3>
+          
+          <!-- Exercise Notes -->
+          <div v-if="exercise.notes" class="mb-3 p-3 bg-primary/5 border border-primary/20 rounded-lg">
+            <div class="flex items-start gap-2">
+              <svg class="w-4 h-4 text-primary flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+              <div class="text-sm text-gray-300">{{ exercise.notes }}</div>
+            </div>
+          </div>
+
           <div class="space-y-2">
             <div
               v-for="(set, index) in exercise.sets"


### PR DESCRIPTION
This pull request introduces a new "notes" feature for workout exercises, allowing users to add, view, and manage notes for each exercise throughout the stack (database, backend, and frontend). The changes include database schema updates, API adjustments, model and schema updates, and new UI components for creating and displaying notes.

**Backend and Database Changes:**

* Added a new nullable `notes` column to the `workout_exercises` table via Alembic migration.
* Updated the `WorkoutExercise` SQLAlchemy model to include a `notes` field.
* Modified backend schemas (`WorkoutExerciseCreate`, `WorkoutExerciseOut`) to include an optional `notes` field. [[1]](diffhunk://#diff-0be30bb501d112ed7cb64b65002481973b74b4d0f320af72613d2fc62f87bcf7R13) [[2]](diffhunk://#diff-0be30bb501d112ed7cb64b65002481973b74b4d0f320af72613d2fc62f87bcf7R35)
* Updated workout creation logic to accept and persist notes for each exercise.

**Frontend Changes:**

* Added a notes button to each exercise in `HomeView.vue`, which opens a modal for entering or editing notes. [[1]](diffhunk://#diff-dceb04b2665ab7f7cded977af468867736a93e1a7377e79c1c934c096b22224eR127-R137) [[2]](diffhunk://#diff-dceb04b2665ab7f7cded977af468867736a93e1a7377e79c1c934c096b22224eR148) [[3]](diffhunk://#diff-dceb04b2665ab7f7cded977af468867736a93e1a7377e79c1c934c096b22224eR328-R367)
* Implemented modal logic and state management for editing and saving exercise notes in `HomeView.vue`. [[1]](diffhunk://#diff-dceb04b2665ab7f7cded977af468867736a93e1a7377e79c1c934c096b22224eR405-R408) [[2]](diffhunk://#diff-dceb04b2665ab7f7cded977af468867736a93e1a7377e79c1c934c096b22224eR636-R659)
* Ensured that notes are included when adding exercises from the library and when submitting a finished workout. [[1]](diffhunk://#diff-dceb04b2665ab7f7cded977af468867736a93e1a7377e79c1c934c096b22224eR620) [[2]](diffhunk://#diff-dceb04b2665ab7f7cded977af468867736a93e1a7377e79c1c934c096b22224eR672)
* Displayed exercise notes in the progress view if present, styled with a dedicated icon and container.