### PR TITLE
[#29] Re-style the workout duration element

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -12,7 +12,7 @@
     </div>
 
     <!-- Progress Rings -->
-    <div class="flex justify-around lg:justify-center lg:gap-12 px-5 lg:px-8 mb-5">
+    <div class="flex justify-center items-center lg:gap-12 px-5 lg:px-8 mb-5">
       <div class="text-center">
         <div class="relative w-20 h-20 mx-auto mb-2">
           <svg class="transform -rotate-90 w-20 h-20">
@@ -36,6 +36,15 @@
         <div class="text-xs text-gray-500">Exercises</div>
       </div>
 
+      <div class="text-center mx-8 lg:mx-12">
+        <div class="flex flex-col items-center justify-center h-20 mb-2 w-24">
+          <div class="text-3xl font-bold tabular-nums">
+            {{ formattedDuration }}
+          </div>
+        </div>
+        <div class="text-xs text-gray-500">Duration</div>
+      </div>
+
       <div class="text-center">
         <div class="relative w-20 h-20 mx-auto mb-2">
           <svg class="transform -rotate-90 w-20 h-20">
@@ -57,29 +66,6 @@
           </div>
         </div>
         <div class="text-xs text-gray-500">Sets Done</div>
-      </div>
-
-      <div class="text-center">
-        <div class="relative w-20 h-20 mx-auto mb-2">
-          <svg class="transform -rotate-90 w-20 h-20">
-            <circle cx="40" cy="40" r="32" stroke="#2a2a2a" stroke-width="8" fill="none" />
-            <circle
-              cx="40"
-              cy="40"
-              r="32"
-              stroke="#FFA07A"
-              stroke-width="8"
-              fill="none"
-              :stroke-dasharray="circumference"
-              :stroke-dashoffset="durationRingOffset"
-              class="transition-all duration-500"
-            />
-          </svg>
-          <div class="absolute inset-0 flex items-center justify-center text-sm font-bold">
-            {{ formattedDuration }}
-          </div>
-        </div>
-        <div class="text-xs text-gray-500">Duration</div>
       </div>
     </div>
 


### PR DESCRIPTION
This pull request updates the display of the "Duration" metric in the `HomeView.vue` component to improve its visual consistency and layout. The duration is now shown as a numeric value with a label, matching the style of the other metrics, and the previous progress ring visualization for duration has been removed.

Layout and UI improvements:

* Replaced the circular progress ring for "Duration" with a simple numeric display, making it visually consistent with the other metrics shown on the page. (`frontend/src/views/HomeView.vue`) [[1]](diffhunk://#diff-dceb04b2665ab7f7cded977af468867736a93e1a7377e79c1c934c096b22224eR39-R47) [[2]](diffhunk://#diff-dceb04b2665ab7f7cded977af468867736a93e1a7377e79c1c934c096b22224eL61-L83)
* Adjusted the flexbox layout for the metrics section to ensure all metrics, including the new duration display, are centered and spaced evenly. (`frontend/src/views/HomeView.vue`)