### PR TITLE
[#36] Add additional platforms to image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.BACKEND_IMAGE }}:${{ steps.version.outputs.tag }}
@@ -52,6 +53,7 @@ jobs:
         with:
           context: ./frontend
           file: ./frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.FRONTEND_IMAGE }}:${{ steps.version.outputs.tag }}


### PR DESCRIPTION
This pull request updates the release workflow to improve Docker image compatibility. The most important change is that both backend and frontend Docker images are now built for multiple architectures, making them usable on a wider range of systems.

**Workflow enhancements:**

* Updated the Docker build steps for both `backend` and `frontend` in `.github/workflows/release.yml` to build multi-architecture images for `linux/amd64` and `linux/arm64`. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R44) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R56)